### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
     branches: [ main ]
+permissions:
+  contents: read
 jobs:
   test:
     name: Python ${{ matrix.python-version }}


### PR DESCRIPTION
Potential fix for [https://github.com/akabarki76/bugster-cli/security/code-scanning/1](https://github.com/akabarki76/bugster-cli/security/code-scanning/1)

The best way to fix this issue is to add a `permissions` block at the root level of the workflow file. Since the workflow only performs read operations (checking out code and installing dependencies) and does not require write permissions, we can restrict the token to `contents: read`. This ensures that the workflow's `GITHUB_TOKEN` has only the minimal permissions required to execute the tasks.

The changes will be made in the `.github/workflows/ci.yml` file, adding a `permissions` block at the root level to restrict permissions for all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
